### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ The npm installation is preferred, but Bower works, too.
 bower install  --save videojs-flash
 ```
 
+You can also use it via a CDN:
+ ```html
+<script src="https://cdn.jsdelivr.net/npm/videojs-flash@2/dist/videojs-flash.min.js"></script>
+ ```
+
 ## Adding the Flash Tech to video.js
 
 To include videojs-flash on your website or web application, use any of the following methods.


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/videojs-flash) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage. 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
