### PR TITLE
Fix 'No compatible source issue was found for this media' error

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^1.21.0",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "^0.50",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -822,10 +822,10 @@ Flash.isSupported = function() {
   // for IE
   if (videojs.browser.IE_VERSION >= 11) {
     return Flash.version()[0] >= 10;
-  } else {
-    // for other browsers
-    return true;
-  }
+  } 
+  // for other browsers
+  return true;
+  
 };
 
 // Add Source Handler pattern functions to this tech

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -819,7 +819,7 @@ for (let i = 0; i < _readOnly.length; i++) {
  *          - False otherwise.
  */
 Flash.isSupported = function() {
-  return Flash.version()[0] >= 10;
+  return true; 
   // return swfobject.hasFlashPlayerVersion('10');
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -815,16 +815,15 @@ for (let i = 0; i < _readOnly.length; i++) {
  * Check if the Flash tech is currently supported.
  *
  * @return {boolean}
- *          - True always as the latest versions of Chrome and Firefox automatically 
+ *          - True always as the latest versions of Chrome and Firefox automatically
  *            blocks flash by default.
  */
 Flash.isSupported = function() {
   // for IE
-  if (videojs.browser.IE_VERSION >=11) {
+  if (videojs.browser.IE_VERSION >= 11) {
     return Flash.version()[0] >= 10;
-  }
-  // for other browsers
-  else {
+  } else {
+    // for other browsers
     return true;
   }
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -820,7 +820,7 @@ for (let i = 0; i < _readOnly.length; i++) {
  */
 Flash.isSupported = function() {
   // for IE
-  if (videojs.browser.IE_VERSION >= 11) {
+  if (videojs.browser.IE_VERSION) {
     return Flash.version()[0] >= 10;
   }
   // for other browsers

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -815,16 +815,16 @@ for (let i = 0; i < _readOnly.length; i++) {
  * Check if the Flash tech is currently supported.
  *
  * @return {boolean}
- *          - True always as the latest versions of Chrome and Firefox automatically
- *            blocks flash by default.
+ *          - True for Chrome and Safari Desktop and if flash tech is supported
+ *          - False otherwise
  */
 Flash.isSupported = function() {
-  // for IE
-  if (videojs.browser.IE_VERSION) {
-    return Flash.version()[0] >= 10;
+  // for Chrome Desktop and Safari Desktop
+  if (videojs.browser.IS_CHROME || videojs.browser.IS_SAFARI) {
+    return true;
   }
   // for other browsers
-  return true;
+  return Flash.version()[0] >= 10;
 };
 
 // Add Source Handler pattern functions to this tech

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -815,12 +815,18 @@ for (let i = 0; i < _readOnly.length; i++) {
  * Check if the Flash tech is currently supported.
  *
  * @return {boolean}
- *          - True if the flash tech is supported.
- *          - False otherwise.
+ *          - True always as the latest versions of Chrome and Firefox automatically 
+ *            blocks flash by default.
  */
 Flash.isSupported = function() {
-  return true; 
-  // return swfobject.hasFlashPlayerVersion('10');
+  // for IE
+  if (videojs.browser.IE_VERSION >=11) {
+    return Flash.version()[0] >= 10;
+  }
+  // for other browsers
+  else {
+    return true;
+  }
 };
 
 // Add Source Handler pattern functions to this tech

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -822,10 +822,9 @@ Flash.isSupported = function() {
   // for IE
   if (videojs.browser.IE_VERSION >= 11) {
     return Flash.version()[0] >= 10;
-  } 
+  }
   // for other browsers
   return true;
-  
 };
 
 // Add Source Handler pattern functions to this tech

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -820,7 +820,8 @@ for (let i = 0; i < _readOnly.length; i++) {
  */
 Flash.isSupported = function() {
   // for Chrome Desktop and Safari Desktop
-  if (videojs.browser.IS_CHROME || videojs.browser.IS_SAFARI) {
+  if ((videojs.browser.IS_CHROME && !videojs.browser.IS_ANDROID) ||
+    (videojs.browser.IS_SAFARI && !videojs.browser.IS_IOS)) {
     return true;
   }
   // for other browsers


### PR DESCRIPTION
## Description
https://github.com/videojs/videojs-flash/issues/26

## Specific Changes proposed
Latest versions of chrome and Firefox automatically block flash by default so by removing the check from the tech that checks whether flash is available, we will add the object to the page which is set to use flash player to always enable flash 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
