### PR TITLE
Fix TimeUI update on seek

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^1.21.0",
     "rimraf": "^2.6.1",
-    "rollup": "0.41.6",
+    "rollup": "^0.50",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^1.21.0",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -39,6 +39,7 @@ class Flash extends Tech {
   */
   constructor(options, ready) {
     super(options, ready);
+    this.player_ = videojs(options.playerId);
 
     // Set the source when ready
     if (options.source) {
@@ -218,6 +219,8 @@ class Flash extends Tech {
       this.lastSeekTarget_ = time;
       this.trigger('seeking');
       this.el_.vjs_setProperty('currentTime', time);
+      // set currentTime cache
+      this.player_.currentTime();
       super.setCurrentTime();
     }
   }


### PR DESCRIPTION
## Description
timeupdate ui does not fire on seek when paused. This is because this plugin relies on artificial timeupdates from https://github.com/videojs/video.js/blob/master/src/js/tech/tech.js#L124.
It calls `manualTimeUpdatesOn` , which doesn't update currenttime when video is paused 
This means that the current time UI doesn't have a trigger to update.

## Specific Changes proposed
This PR sets the currentTime cache which helps in updating timeui

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
