### PR TITLE
forward errors from swf without altering when error is not just a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "npm-run-all": "^4.0.2",
     "qunitjs": "^1.21.0",
     "rimraf": "^2.6.1",
-    "rollup": "^0.41.6",
+    "rollup": "^0.51.0",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-json": "^2.1.1",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1026,6 +1026,7 @@ Flash.onError = function(swfID, err) {
   if (typeof err === 'string') {
     tech.error('FLASH: ' + err);
   } else {
+    err.origin = 'flash';
     tech.error(err);
   }
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1023,7 +1023,11 @@ Flash.onError = function(swfID, err) {
   }
 
   // trigger a custom error
-  tech.error('FLASH: ' + err);
+  if (typeof err === 'string') {
+    tech.error('FLASH: ' + err);
+  } else {
+    tech.error(err);
+  }
 };
 
 /**


### PR DESCRIPTION
This allows a custom swf to emit error objects with properties such as `code`,`type`, and `message` without having the tech alter the message