### PR TITLE
fix: rtmp parameters can contains "-"

### DIFF
--- a/src/rtmp.js
+++ b/src/rtmp.js
@@ -70,7 +70,7 @@ function FlashRtmpDecorator(Flash) {
     // Look for the normal URL separator we expect, '&'.
     // If found, we split the URL into two pieces around the
     // first '&'.
-    let connEnd = src.search(/&(?!\w+=)/);
+    let connEnd = src.search(/&(?![\w-]+=)/);
     let streamBegin;
 
     if (connEnd !== -1) {


### PR DESCRIPTION
## Description
RTMP connection parameter can contain dash character, which breaks the connection / stream split

