### PR TITLE
Return turn for support microsoft edge

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -815,13 +815,14 @@ for (let i = 0; i < _readOnly.length; i++) {
  * Check if the Flash tech is currently supported.
  *
  * @return {boolean}
- *          - True for Chrome and Safari Desktop and if flash tech is supported
+ *          - True for Chrome and Safari Desktop and Microsoft Edge and if flash tech is supported
  *          - False otherwise
  */
 Flash.isSupported = function() {
   // for Chrome Desktop and Safari Desktop
   if ((videojs.browser.IS_CHROME && !videojs.browser.IS_ANDROID) ||
-    (videojs.browser.IS_SAFARI && !videojs.browser.IS_IOS)) {
+    (videojs.browser.IS_SAFARI && !videojs.browser.IS_IOS) ||
+    videojs.browser.IS_EDGE) {
     return true;
   }
   // for other browsers


### PR DESCRIPTION
## Description
Fixed in #98.

## Specific Changes proposed
Because Microsoft Edge automatically block flash by default, so we should set to use flash player to always enable flash. 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
