### PR TITLE
fix: ignore Chrome on iOS

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -820,7 +820,7 @@ for (let i = 0; i < _readOnly.length; i++) {
  */
 Flash.isSupported = function() {
   // for Chrome Desktop and Safari Desktop
-  if ((videojs.browser.IS_CHROME && !videojs.browser.IS_ANDROID) ||
+  if ((videojs.browser.IS_CHROME && (!videojs.browser.IS_ANDROID || !videojs.browser.IS_IOS)) ||
     (videojs.browser.IS_SAFARI && !videojs.browser.IS_IOS) ||
     videojs.browser.IS_EDGE) {
     return true;


### PR DESCRIPTION
We can get Chrome on iOS as well and Flash is never supported on mobile.

Fixes #142.